### PR TITLE
#comment removed link since its not needed

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,7 +60,7 @@ pub use Synchronization::*;
 
 use raw::*;
 
-#[link(name = "rt")]
+//#[link(name = "rt")]
 extern {
     fn clock_gettime(clkid: libc::c_int, res: *mut libc::timespec);
 }


### PR DESCRIPTION
Not needed it seems for most of the linker operations and was causing errors for me.